### PR TITLE
fix: `callback` prop types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
+export { scanText } from './scanText';
+
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;
   // @ts-ignore

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-native-vision-camera';
 import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
-import type { CameraTypes, Frame, FrameProcessor } from './types';
+import type { CameraTypes, Frame, FrameProcessor, TextDataMap } from './types';
 
 export { scanText } from './scanText';
 export type { TextData, TextDataMap } from './types';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,8 @@ import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
-export { scanText, type TextData, type TextDataMap } from './scanText';
+export { scanText } from './scanText';
+export type { TextData, TextDataMap } from './types';
 
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,19 +7,19 @@ import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
 import type { CameraTypes, Frame, FrameProcessor } from './types';
 
-export { scanText } from './scanText';
+export { scanText, type TextData, type TextDataMap } from './scanText';
 
 export const Camera = forwardRef(function Camera(props: CameraTypes,ref:ForwardedRef<any>) {
   const { callback, device, options } = props;
   // @ts-ignore
-  const useWorklets = useRunInJS((data: object): void => {
+  const useWorklets = useRunInJS((data: TextDataMap): void => {
     callback(data);
   }, []);
   const frameProcessor: FrameProcessor = useFrameProcessor(
     (frame: Frame): void => {
       'worklet';
       // @ts-ignore
-      const data: object = scanText(frame, options);
+      const data = scanText(frame, options);
       // @ts-ignore
       // eslint-disable-next-line react-hooks/rules-of-hooks
       useWorklets(data);

--- a/src/scanText.ts
+++ b/src/scanText.ts
@@ -6,6 +6,30 @@ import type {
 import { VisionCameraProxy } from 'react-native-vision-camera';
 import { Platform } from 'react-native';
 
+export interface TextData {
+  blockFrameBottom: number
+  blockFrameLeft: number
+  blockFrameRight: number
+  blockFrameTop: number
+  blockText: string
+  elementFrameBottom: number
+  elementFrameLeft: number
+  elementFrameRight: number
+  elementFrameTop: number
+  elementText: string
+  lineFrameBottom: number
+  lineFrameLeft: number
+  lineFrameRight: number
+  lineFrameTop: number
+  lineText: string
+  resultText: string
+  size: number
+}
+
+export interface TextDataMap {
+  [key: number]: TextData
+}
+
 const plugin: FrameProcessorPlugin | undefined =
   VisionCameraProxy.initFrameProcessorPlugin('scanText');
 
@@ -15,7 +39,7 @@ const LINKING_ERROR =
   '- You rebuilt the app after installing the package\n' +
   '- You are not using Expo Go\n';
 
-export function scanText(frame: Frame, options: TextRecognitionOptions): any {
+export function scanText(frame: Frame, options: TextRecognitionOptions): TextDataMap {
   'worklet';
   if (plugin == null) throw new Error(LINKING_ERROR);
   // @ts-ignore

--- a/src/scanText.ts
+++ b/src/scanText.ts
@@ -2,33 +2,10 @@ import type {
   Frame,
   FrameProcessorPlugin,
   TextRecognitionOptions,
+  TextDataMap,
 } from './types';
 import { VisionCameraProxy } from 'react-native-vision-camera';
 import { Platform } from 'react-native';
-
-export interface TextData {
-  blockFrameBottom: number
-  blockFrameLeft: number
-  blockFrameRight: number
-  blockFrameTop: number
-  blockText: string
-  elementFrameBottom: number
-  elementFrameLeft: number
-  elementFrameRight: number
-  elementFrameTop: number
-  elementText: string
-  lineFrameBottom: number
-  lineFrameLeft: number
-  lineFrameRight: number
-  lineFrameTop: number
-  lineText: string
-  resultText: string
-  size: number
-}
-
-export interface TextDataMap {
-  [key: number]: TextData
-}
 
 const plugin: FrameProcessorPlugin | undefined =
   VisionCameraProxy.initFrameProcessorPlugin('scanText');

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,30 @@ export interface TextRecognitionOptions {
   language: 'latin' | 'chinese' | 'devanagari' | 'japanese' | 'korean';
 }
 
+export type TextData = {
+  blockFrameBottom: number
+  blockFrameLeft: number
+  blockFrameRight: number
+  blockFrameTop: number
+  blockText: string
+  elementFrameBottom: number
+  elementFrameLeft: number
+  elementFrameRight: number
+  elementFrameTop: number
+  elementText: string
+  lineFrameBottom: number
+  lineFrameLeft: number
+  lineFrameRight: number
+  lineFrameTop: number
+  lineText: string
+  resultText: string
+  size: number
+}
+
+export type TextDataMap = {
+  [key: number]: TextData
+}
+
 export type CameraTypes = {
   callback: Function;
   options: TextRecognitionOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,6 @@ export type TextDataMap = {
 }
 
 export type CameraTypes = {
-  callback: Function;
+  callback: (data: TextDataMap) => void;
   options: TextRecognitionOptions;
 } & CameraProps;


### PR DESCRIPTION
Adds `TextDataMap` in `callback`

```ts
export type CameraTypes = {
  callback: (data: TextDataMap) => void;
  options: TextRecognitionOptions;
} & CameraProps;
```

#### usage
```tsx
       callback={(data) => {
            const map: Map<string, typeof data> = new Map(Object.entries(data))
            const result = map.get('0')
            console.log(result)
          }}
```