### PR TITLE
fix(Android): upgrade react-native-vision-camera v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ android/keystores/debug.keystore
 .yarnrc.yml
 .yarn
 yarn.lock
+.pnp/
+.pnp.*
 # Expo
 .expo/
 

--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,13 @@ android/keystores/debug.keystore
 !.yarn/versions
 .yarnrc.yml
 .yarn
-yarn.lock
 .pnp/
 .pnp.*
+
+# Lockfiles
+yarn.lock
+package-lock.json
+
 # Expo
 .expo/
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,5 +96,6 @@ dependencies {
   implementation 'com.google.mlkit:text-recognition-japanese:16.0.0'
   implementation 'com.google.mlkit:text-recognition-korean:16.0.0'
   implementation project(':react-native-vision-camera')
+  implementation "androidx.camera:camera-core:1.1.0"
 }
 

--- a/android/src/main/java/com/visioncamerav3textrecognition/VisionCameraV3TextRecognitionModule.kt
+++ b/android/src/main/java/com/visioncamerav3textrecognition/VisionCameraV3TextRecognitionModule.kt
@@ -14,18 +14,15 @@ import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions
 import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
 import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
-import com.mrousavy.camera.frameprocessor.Frame
-import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
-import com.mrousavy.camera.frameprocessor.VisionCameraProxy
-import com.mrousavy.camera.types.Orientation
-
+import com.mrousavy.camera.frameprocessors.Frame
+import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
+import com.mrousavy.camera.frameprocessors.VisionCameraProxy
 
 class VisionCameraV3TextRecognitionModule(proxy : VisionCameraProxy, options: Map<String, Any>?): FrameProcessorPlugin() {
   override fun callback(frame: Frame, arguments: Map<String, Any>?): Any {
       try {
         val mediaImage: Image = frame.image
-        val orientation : Orientation = frame.orientation
-        val image = InputImage.fromMediaImage(mediaImage, orientation.toDegrees())
+        val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
         val recognizer : TextRecognizer = when (arguments?.get("language")) {
           "latin" -> TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
           "chinese" -> TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())

--- a/android/src/main/java/com/visioncamerav3textrecognition/VisionCameraV3TextRecognitionPackage.kt
+++ b/android/src/main/java/com/visioncamerav3textrecognition/VisionCameraV3TextRecognitionPackage.kt
@@ -4,7 +4,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.bridge.NativeModule
-import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry
+import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
 
 class VisionCameraV3TextRecognitionPackage : ReactPackage {
    companion object {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-builder-bob": "^0.23.2",
-    "react-native-vision-camera": "3.9.1",
-    "react-native-worklets-core": "0.4.0",
+    "react-native-vision-camera": "^4.0.1",
+    "react-native-worklets-core": "^1.1.1",
     "release-it": "^15.0.0",
     "turbo": "^1.10.7",
     "typescript": "^5.2.2"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-native-vision-camera';
 import { useRunInJS } from 'react-native-worklets-core';
 import { scanText } from './scanText';
-import type { CameraTypes, Frame, FrameProcessor, TextDataMap } from './types';
+import type { CameraTypes, Frame, ReadonlyFrameProcessor, TextDataMap } from './types';
 
 export { scanText } from './scanText';
 export type { TextData, TextDataMap } from './types';
@@ -19,7 +19,7 @@ export const Camera = forwardRef(function Camera(
   const useWorklets = useRunInJS((data: TextDataMap): void => {
     callback(data);
   }, []);
-  const frameProcessor: FrameProcessor = useFrameProcessor(
+  const frameProcessor: ReadonlyFrameProcessor = useFrameProcessor(
     (frame: Frame): void => {
       'worklet';
       // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ export type {
   CameraProps,
   Frame,
   FrameProcessorPlugin,
-  FrameProcessor,
+  ReadonlyFrameProcessor,
 } from 'react-native-vision-camera';
 import type { CameraProps } from 'react-native-vision-camera';
 export interface TextRecognitionOptions {


### PR DESCRIPTION
# Fix Android support for `react-native-vision-camera` release [v4.0.0](https://github.com/mrousavy/react-native-vision-camera/releases/tag/v4.0.0)

- [changelog](https://github.com/mrousavy/react-native-vision-camera/compare/v3.9.2...v4.0.0)

> [!CAUTION]
> This will break in `react-native-vision` releases before v4.0.0

## Upgrade

### Dependencies
```json
    "react-native-vision-camera": "3.9.1",
    "react-native-worklets-core": "0.4.0",
```
```json
    "react-native-vision-camera": "^4.0.1",
    "react-native-worklets-core": "^1.1.1",
```

## Fix 

### `com.mrousavy.camera.frameprocessor` imports

```kt
import com.mrousavy.camera.frameprocessor.Frame
import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
import com.mrousavy.camera.frameprocessor.VisionCameraProxy
```

```kt
import com.mrousavy.camera.frameprocessors.Frame
import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
import com.mrousavy.camera.frameprocessors.VisionCameraProxy
```

### `toDegrees()` method

`orientation.toDegrees()` was removed in v4

```kt
val image = InputImage.fromMediaImage(mediaImage, orientation.toDegrees())
```

```kt
val image = InputImage.fromMediaImage(mediaImage, frame.imageProxy.imageInfo.rotationDegrees)
```

### type `FrameProcessor`

type FrameProcessor was replaced with ReadonlyFrameProcessor